### PR TITLE
Checks if a package exists on PyPI prior to obtaining link count.

### DIFF
--- a/pep438/core.py
+++ b/pep438/core.py
@@ -6,6 +6,14 @@ import lxml.html
 from reqfileparser import parse
 
 
+def valid_package(package_name):
+    """Return bool if package_name is a valid package on PyPI"""
+    response = requests.head('https://pypi.python.org/pypi/%s' % package_name)
+    if response.status_code != 404:
+        response.raise_for_status()
+    return response.status_code != 404
+
+
 def get_links(package_name):
     """Return list of links on package's PyPI page"""
     response = requests.get('https://pypi.python.org/simple/%s' % package_name)

--- a/pep438/main.py
+++ b/pep438/main.py
@@ -9,7 +9,7 @@ from clint.textui.core import STDOUT, STDERR
 from clint.textui.colored import green, red, blue
 
 from . import __version__
-from .core import get_links, get_pypi_packages
+from .core import get_links, get_pypi_packages, valid_package
 
 
 def version():
@@ -78,6 +78,12 @@ def main():
         sys.exit(2)
 
     for package in packages:
-        links = get_links(package)
-        symbol = red('\u2717') if links else green('\u2713')
-        print("%s %s: %s links" % (symbol, blue(package), len(links)))
+        if valid_package(package):
+            links = get_links(package)
+            symbol = red('\u2717') if links else green('\u2713')
+            msg = "%s %s: %s links" % (symbol, blue(package), len(links))
+            print(msg)
+        else:
+            symbol = red('\u2717')
+            msg = "%s %s: not found on PyPI" % (symbol, blue(package))
+            sys.stderr.write(msg)

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
     ],
+    tests_require=["mock==1.0.1"],
     test_suite='test_pep438',
 )


### PR DESCRIPTION
Fixes #4

The loop in main probably needs some refactoring. Feel free to alter output to taste.

py27: commands succeeded
py33: commands succeeded
flake8: commands succeeded
congratulations :)

$ pep438 requests
✓ requests: 0 links

$ pep438 requestsa
✗ requestsa: not found on PyPI
