### PR TITLE
Replaced lxml with xml.etree.ElementTree

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changes
 -----
 
 - Pin requirements-parser to version 0.4.0
+- Replaced lxml with xml.etree.ElementTree
 
 0.4.0
 -----

--- a/pep438/core.py
+++ b/pep438/core.py
@@ -5,8 +5,8 @@ import requests
 try:
     import xmlrpclib
 except:
-    import xmlrpc.client as xmlprclib
-import lxml.html
+    import xmlrpc.client as xmlrpclib  # noqa
+from xml.etree import ElementTree
 from requirements import parse
 
 
@@ -22,8 +22,8 @@ def get_urls(package_name):
     """Return list of URLs on package's PyPI page that would be crawled"""
     response = requests.get('https://pypi.python.org/simple/%s' % package_name)
     response.raise_for_status()
-    page = lxml.html.fromstring(response.content)
-    crawled_urls = {link.get('href') for link in page.xpath('//a')
+    page = ElementTree.fromstring(response.content)
+    crawled_urls = {link.get('href') for link in page.findall('.//a')
                     if link.get('rel') in ("homepage", "download")}
     return crawled_urls
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         'requirements-parser==0.0.4',
         'clint',
         'requests',
-        'lxml',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Both flake8 related failures are due to the try: except: importing of xmlrpclib
    pep438/core.py:6:1: PY3K (FixImports) import xmlrpclib; -> import xmlrpc.client;
    pep438/core.py:37:1: PY3K (FixImports) xmlrpclib.ServerProxy('https://pypi.python.org/pypi'); -> xmlrpc.client.ServerProxy('https://pypi.python.org/pypi');
