### PR TITLE
Remove PyPI download count

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,6 @@ pep438
    :target: https://coveralls.io/r/treyhunner/pep438
 .. image:: https://pypip.in/v/pep438/badge.png
    :target: https://crate.io/packages/pep438
-.. image:: https://pypip.in/d/pep438/badge.png
-   :target: https://crate.io/packages/pep438
 
 
 Check packages in your requirements file for proper usage of the `PEP 438`_ tools.


### PR DESCRIPTION
The download count was removed last month.

http://mail.python.org/pipermail/distutils-sig/2013-May/020855.html
