### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ pep438
    :target: http://travis-ci.org/treyhunner/pep438
 .. image:: https://coveralls.io/repos/treyhunner/pep438/badge.png?branch=master
    :target: https://coveralls.io/r/treyhunner/pep438
-.. image:: https://pypip.in/v/pep438/badge.png
+.. image:: https://img.shields.io/pypi/v/pep438.svg
    :target: https://crate.io/packages/pep438
 .. image:: https://requires.io/github/treyhunner/pep438/requirements.png?branch=master
    :target: https://requires.io/github/treyhunner/pep438/requirements/?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pep438))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pep438`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.